### PR TITLE
Update from Ghost 0.8.0 to Ghost 0.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL https://deb.nodesource.com/setup | sudo bash - && \
 
 
 # Install ghost
-ENV GHOST_VERSION=0.8.0
+ENV GHOST_VERSION=0.11.2
 RUN wget -qO ghost.zip https://ghost.org/zip/ghost-${GHOST_VERSION}.zip && \
     rm -rf /var/www && \
     unzip ghost.zip -d /var/www/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM scaleway/ubuntu:amd64-trusty
 # following 'FROM' lines are used dynamically thanks do the image-builder
 # which dynamically update the Dockerfile if needed.
 #FROM scaleway/ubuntu:armhf-trusty       # arch=armv7l
-#FROM scaleway/ubuntu:arm64-trusty      # arch=arm64
+#FROM scaleway/ubuntu:arm64-trusty       # arch=arm64
 #FROM scaleway/ubuntu:i386-trusty        # arch=i386
 #FROM scaleway/ubuntu:mips-trusty        # arch=mips
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## -*- docker-image-name: "scaleway/python:latest" -*-
-FROM scaleway/ubuntu:amd64-trusty
+FROM scaleway/ubuntu:amd64-xenial
 # following 'FROM' lines are used dynamically thanks do the image-builder
 # which dynamically update the Dockerfile if needed.
 #FROM scaleway/ubuntu:armhf-trusty       # arch=armv7l

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ## -*- docker-image-name: "scaleway/python:latest" -*-
-FROM scaleway/ubuntu:amd64-xenial
+FROM scaleway/ubuntu:amd64-trusty
 # following 'FROM' lines are used dynamically thanks do the image-builder
 # which dynamically update the Dockerfile if needed.
 #FROM scaleway/ubuntu:armhf-trusty       # arch=armv7l
-#FROM scaleway/ubuntu:arm64-trusty       # arch=arm64
+#FROM scaleway/ubuntu:arm64-trusty      # arch=arm64
 #FROM scaleway/ubuntu:i386-trusty        # arch=i386
 #FROM scaleway/ubuntu:mips-trusty        # arch=mips
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME =			ghost
 VERSION =		latest
-VERSION_ALIASES =	0.8.0
+VERSION_ALIASES =	0.11.2
 TITLE =			Ghost
 DESCRIPTION =		Ghost blogging platform
 SOURCE_URL =		https://github.com/scaleway-community/scaleway-ghost
@@ -9,7 +9,7 @@ DEFAULT_IMAGE_ARCH =	x86_64
 
 IMAGE_VOLUME_SIZE =	50G
 IMAGE_BOOTSCRIPT =	stable
-IMAGE_NAME =		Ghost 0.8.0
+IMAGE_NAME =		Ghost 0.11.2
 
 
 ## Image tools  (https://github.com/scaleway/image-tools)

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-NAME =			ghost
-VERSION =		latest
+NAME = ghost
+VERSION =	latest
 VERSION_ALIASES =	0.11.2
-TITLE =			Ghost
-DESCRIPTION =		Ghost blogging platform
-SOURCE_URL =		https://github.com/scaleway-community/scaleway-ghost
-VENDOR_URL =		https://ghost.org/
+TITLE =	Ghost
+DESCRIPTION =	Ghost blogging platform
+SOURCE_URL =	https://github.com/scaleway-community/scaleway-ghost
+VENDOR_URL =	https://ghost.org/
 DEFAULT_IMAGE_ARCH =	x86_64
 
 IMAGE_VOLUME_SIZE =	50G
-IMAGE_BOOTSCRIPT =	stable
-IMAGE_NAME =		Ghost 0.11.2
+IMAGE_BOOTSCRIPT = stable
+IMAGE_NAME = Ghost 0.11.2
 
 
 ## Image tools  (https://github.com/scaleway/image-tools)


### PR DESCRIPTION
On the Dockerfile and Makefile the version of Ghost is on 0.8.0; the current version is 0.11.2. 

This are the changes that are in Ghost 0.11.2

>[Fixed] The memory leak is really actually gone this time 🤐
[Fixed] Removed deprecated body classes from Casper 🙅🏽
[Fixed] Allow database migrations to run if the active theme is not present 🐛
[Security] Prevent bad urls from being passed to the subscribers page 🚫
And several dependency updates

It would also help a lot if Ubuntu is updated to 16.04 LTS Xenial.